### PR TITLE
Allow changing glob in video command

### DIFF
--- a/lib/tlapse/cli/alpha.rb
+++ b/lib/tlapse/cli/alpha.rb
@@ -24,7 +24,7 @@ module Tlapse::CLI
       server.serve
     end
 
-    desc "compile", "Use ffmpeg to combine all .jpg files in the current directory"
+    desc "compile", "Use ffmpeg to combine .jpg"
     option :force,
       desc: "Force overwrite any existing output files",
       type: :boolean,
@@ -35,12 +35,19 @@ module Tlapse::CLI
       type: :string,
       default: "out.mkv",
       aliases: %i(o)
+    option :glob,
+      desc: "Specify how to find input images, e.g. `*.JPEG`",
+      type: :string,
+      default: "**/*.jpg"
     def compile
-      video = Tlapse::Video.new out: options[:out]
+      video = Tlapse::Video.new(
+        glob: options[:glob],
+        out: options[:out]
+      )
 
       if video.outfile_exists?
         if options[:force]
-          FileUtils.rm video.outfile
+          FileUtils.rm(video.outfile)
           puts "Removed file #{video.outfile}"
         else
           Tlapse::Logger.error! "#{video.outfile} exists. Use -f to overwrite or " \

--- a/lib/tlapse/cli/alpha.rb
+++ b/lib/tlapse/cli/alpha.rb
@@ -24,7 +24,7 @@ module Tlapse::CLI
       server.serve
     end
 
-    desc "compile", "Use ffmpeg to combine .jpg"
+    desc "compile", "Use ffmpeg to combine .jpg files into a video"
     option :force,
       desc: "Force overwrite any existing output files",
       type: :boolean,

--- a/lib/tlapse/video.rb
+++ b/lib/tlapse/video.rb
@@ -3,16 +3,17 @@ module Tlapse
     attr_accessor *%i(size framerate codec outfile)
 
     def initialize(opts)
-      @size      = opts.fetch :size,      "1920x1080"
-      @framerate = opts.fetch :framerate, "60"
-      @codec     = opts.fetch :codec,     "libx264"
-      @outfile   = opts.fetch :out,       "out.mkv"
+      @codec = opts.fetch(:codec, "libx264")
+      @framerate = opts.fetch(:framerate, "60")
+      @glob = opts.fetch(:glob, "**/*.jpg")
+      @outfile = opts.fetch(:out, "out.mkv")
+      @size = opts.fetch(:size, "1920x1080")
     end
 
     def create_command
       command = "ffmpeg"
       command += " -pattern_type glob"
-      command += " -i '*.jpg'"
+      command += " -i '#{@glob}'"
       command += " -s #{@size}"
       command += " -r #{@framerate}"
       command += " -vcodec #{@codec}"

--- a/spec/tlapse/video_spec.rb
+++ b/spec/tlapse/video_spec.rb
@@ -8,7 +8,7 @@ describe Tlapse::Video do
 
       command = video.create_command
 
-      expect(command).to include("-i #{glob}")
+      expect(command).to include("-i '#{glob}'")
     end
   end
 end

--- a/spec/tlapse/video_spec.rb
+++ b/spec/tlapse/video_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+describe Tlapse::Video do
+  describe "#create_command" do
+    it "adds the glob I pass in" do
+      glob = "asdf-*.jpg"
+      video = Tlapse::Video.new(glob: glob)
+
+      command = video.create_command
+
+      expect(command).to include("-i #{glob}")
+    end
+  end
+end


### PR DESCRIPTION
If the default `**/*.jpg` doesn't work for you, you can change it to
anything you like by passing `--glob` to `tlapse alpha compile`.